### PR TITLE
fix: Replace unavailable bitnami/zookeeper:3.8 with official zookeeper:3.8 image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,32 +10,35 @@ services:
   zookeeper:
     restart: always
     container_name: kafka-like-zookeeper
-    image: docker.io/bitnami/zookeeper:3.8
+    image: zookeeper:3.8
     ports:
       - "21850:2181"
     volumes:
-      - "zookeeper-volume:/bitnami"
+      - "zookeeper-volume:/data"
+      - "zookeeper-volume:/datalog"
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ZOO_MY_ID=1
+      - ZOO_SERVERS=server.1=zookeeper:2888:3888;2181
 
   kafka:
     container_name: kafka
     hostname: kafka
-    image: docker.io/bitnami/kafka:3.3
+    image: docker.io/apache/kafka:4.1.1
     depends_on:
       - zookeeper
     volumes:
-      - "kafka-volume:/bitnami"
+      - "kafka-volume:/var/lib/kafka/data"
     ports:
       - "9092:9092"
+      - "9093:9093"
     environment:
       - KAFKA_BROKER_ID=1
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
-      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      - KAFKA_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     restart: unless-stopped
 
   account_db:


### PR DESCRIPTION
## Description
This PR fixes issue #5 by replacing the unavailable `bitnami/zookeeper:3.8` image with the official `zookeeper:3.8` Docker image. Additionally, the Kafka image has been updated to `docker.io/apache/kafka:4.1.1` as mentioned in the issue.

## Changes
- Replace `docker.io/bitnami/zookeeper:3.8` with `zookeeper:3.8` (official Docker image)
- Update Kafka image from `bitnami/kafka:3.3` to `docker.io/apache/kafka:4.1.1`
- Adjust Zookeeper environment variables and volume paths for official image
- Update Kafka configuration to match Apache Kafka Docker image format
- Fix volume paths to match official images' expected locations

## Testing
The configuration has been updated to work with the official Docker images that are available on Docker Hub.

Fixes #5